### PR TITLE
Show count by country in data code summary table

### DIFF
--- a/web/static/css/phoenix.css
+++ b/web/static/css/phoenix.css
@@ -42,12 +42,12 @@ form.link, form.button {
   padding-left: 15px;
 }
 
-/* Customize container */
+/* Customize container
 @media (min-width: 768px) {
   .container {
     max-width: 730px;
   }
-}
+} */
 .container-narrow > hr {
   margin: 30px 0;
 }

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -16,7 +16,7 @@
       <header class="header">
         <h1 class="heading-xlarge">
           <span class="heading-secondary">OpenRegister</span>
-          Local Authority data report
+          Local Authority data codes
         </h1>
       </header>
 

--- a/web/templates/page/comparison_table.html.eex
+++ b/web/templates/page/comparison_table.html.eex
@@ -11,9 +11,13 @@
         <th class=''>Local Authority Type</th>
         <th class=''>Name</th>
         <%= for [file, _] <- @maps_list do %>
+        <%= if !(file == "snac") do %>
         <th><%= file %></th>
         <% end %>
+        <% end %>
+        <!--
         <th class=''>Count</th>
+        -->
       </tr>
     </thead>
     <tbody>

--- a/web/templates/page/comparison_table.html.eex
+++ b/web/templates/page/comparison_table.html.eex
@@ -8,6 +8,7 @@
         <th></th>
         <th class=''>Local Authority</th>
         <th class=''>Country</th>
+        <th class=''>Local Authority Type</th>
         <th class=''>Name</th>
         <%= for [file, _] <- @maps_list do %>
         <th><%= file %></th>

--- a/web/templates/page/data_row.html.eex
+++ b/web/templates/page/data_row.html.eex
@@ -5,10 +5,14 @@
   <td class=''><%= @authority.local_authority_type %></td>
   <td class=''><%= @authority.name %></td>
   <%= for [file, list] <- @data do %>
+  <%= if !(file == "snac") do %>
   <td class=''>
     <% item = match_from_list(list, @authority) %>
-    <%= list |> local_authority_name(@authority, file) %>
+    <%= raw( list |> local_authority_name(@authority, file)) %>
   </td>
   <% end %>
+  <% end %>
+  <!--
   <td class=''><%= match_count(@data, @authority) %></td>
+  -->
 </tr>

--- a/web/templates/page/data_row.html.eex
+++ b/web/templates/page/data_row.html.eex
@@ -2,6 +2,7 @@
   <td></td>
   <td class=''><%= @authority.local_authority <> @authority.end_date %></td>
   <td class=''><%= @authority.uk %></td>
+  <td class=''><%= @authority.local_authority_type %></td>
   <td class=''><%= @authority.name %></td>
   <%= for [file, list] <- @data do %>
   <td class=''>

--- a/web/templates/page/data_summary_table.html.eex
+++ b/web/templates/page/data_summary_table.html.eex
@@ -5,6 +5,8 @@
       <th class='name'>File</th>
       <th>Description</th>
       <th class='count'>In England/Wales Count</th>
+      <th class='count'>In Scotland Count</th>
+      <th class='count'>In NI Count</th>
       <th class='count'>Total Count</th>
       <th>Fields</th>
     </tr>
@@ -15,11 +17,10 @@
         <!--<input type='checkbox' name='local_authority' checked>-->
       </td>
       <td class='name'>local_authority</td>
-      <td><%= '@description["local_authorities"]' %></td>
-      <td class='count'><a href=''><%=
-        @data_list
-        |> Enum.filter(&england_or_wales/1)
-        |> Enum.count %></a></td>
+      <td>Local authorities register records</td>
+      <td class='count'><a href=''><%= @data_list |> count_in(england_or_wales) %></a></td>
+      <td class='count'><a href=''><%= @data_list |> count_in(scotland) %></a></td>
+      <td class='count'><a href=''><%= @data_list |> count_in(northern_ireland) %></a></td>
       <td class='count'><a href=''><%= Enum.count(@data_list) %></a></td>
       <td><%= @data_list |> fields %></td>
     </tr>
@@ -30,11 +31,10 @@
       </td>
       <td class='name'><%= file %></td>
       <td><%= @description[file]["description"] %></td>
-      <td class='count'><a href=''><%=
-        list
-        |> local_authorities(@data_list_by_id)
-        |> Enum.filter(&england_or_wales/1)
-        |> Enum.count %></a></td>
+      <% authorities = list |> local_authorities(@data_list_by_id) %>
+      <td class='count'><a href=''><%= authorities |> count_in(england_or_wales) %></a></td>
+      <td class='count'><a href=''><%= authorities |> count_in(scotland) %></a></td>
+      <td class='count'><a href=''><%= authorities |> count_in(northern_ireland) %></a></td>
       <td class='count'><a href=''><%= Enum.count(list) %></a></td>
       <td><%= list |> fields %></td>
     </tr>

--- a/web/templates/page/data_summary_table.html.eex
+++ b/web/templates/page/data_summary_table.html.eex
@@ -4,11 +4,17 @@
       <th></th>
       <th class='name'>File</th>
       <th>Description</th>
-      <th class='count'>In England/Wales Count</th>
-      <th class='count'>In Scotland Count</th>
-      <th class='count'>In NI Count</th>
-      <th class='count'>Total Count</th>
+      <th>In England Count</th>
+      <th>In Wales Count</th>
+      <th>In Scotland Count</th>
+      <th>In NI Count</th>
+      <th>Historic count</th>
+      <th>Total Count</th>
+      <!--
+      <th>Present</th>
+      <th>Missing</th>
       <th>Fields</th>
+      -->
     </tr>
   </thead>
   <tbody>
@@ -18,11 +24,17 @@
       </td>
       <td class='name'>local_authority</td>
       <td>Local authorities register records</td>
-      <td class='count'><a href=''><%= @data_list |> count_in(england_or_wales) %></a></td>
-      <td class='count'><a href=''><%= @data_list |> count_in(scotland) %></a></td>
-      <td class='count'><a href=''><%= @data_list |> count_in(northern_ireland) %></a></td>
-      <td class='count'><a href=''><%= Enum.count(@data_list) %></a></td>
+      <td><%= @data_list |> count_in(england) %></td>
+      <td><%= @data_list |> count_in(wales) %></td>
+      <td><%= @data_list |> count_in(scotland) %></td>
+      <td><%= @data_list |> count_in(northern_ireland) %></td>
+      <td><%= @data_list |> count_in(end_date_present) %></td>
+      <td><%= Enum.count(@data_list) %></td>
+      <!--
+      <td></td>
+      <td></td>
       <td><%= @data_list |> fields %></td>
+      -->
     </tr>
     <%= for [file, list] <- @maps_list do %>
     <tr id='<%= file %>'>
@@ -32,11 +44,53 @@
       <td class='name'><%= file %></td>
       <td><%= @description[file]["description"] %></td>
       <% authorities = list |> local_authorities(@data_list_by_id) %>
-      <td class='count'><a href=''><%= authorities |> count_in(england_or_wales) %></a></td>
-      <td class='count'><a href=''><%= authorities |> count_in(scotland) %></a></td>
-      <td class='count'><a href=''><%= authorities |> count_in(northern_ireland) %></a></td>
-      <td class='count'><a href=''><%= Enum.count(list) %></a></td>
+      <td><%= authorities |> count_in(england) %></td>
+      <td><%= authorities |> count_in(wales) %></td>
+      <td><%= authorities |> count_in(scotland) %></td>
+      <td><%= authorities |> count_in(northern_ireland) %></td>
+      <td><%= authorities |> count_in(end_date_present) %></td>
+      <td><%= Enum.count(list) %></td>
+      <!--
+      <td><% present = @data_list
+      |> Enum.filter(&(!end_date_present.(&1)))
+      |> Enum.map(&(&1.local_authority))
+      |> Enum.into(MapSet.new)
+      |> MapSet.intersection(Enum.map(authorities, &(&1.local_authority)) |> Enum.into(MapSet.new))
+      |> Enum.map(&(
+        item = @data_list_by_id
+        |> Map.get(&1)
+        |> List.first
+        |> label_type
+      ))
+
+      %>
+      <%= present
+      |> Enum.count%>
+      <%= present
+      |> Enum.uniq |> Enum.join(", ")%>
+    </td>
+      <td><% missing = @data_list
+      |> Enum.filter(&(!end_date_present.(&1)))
+      |> Enum.filter(&(!northern_ireland.(&1)))
+      |> Enum.filter(&(&1.local_authority !=  "GLA" ))
+      |> Enum.map(&(&1.local_authority))
+      |> Enum.into(MapSet.new)
+      |> MapSet.difference(Enum.map(authorities, &(&1.local_authority)) |> Enum.into(MapSet.new))
+      |> Enum.map(&(
+        item = @data_list_by_id
+        |> Map.get(&1)
+        |> List.first
+        |> label_type
+      ))
+
+      %>
+      <%= missing
+      |> Enum.count%>
+      <%= missing
+      |> Enum.uniq |> Enum.join(", ")%>
+    </td>
       <td><%= list |> fields %></td>
+    -->
     </tr>
     <% end %>
   </tbody>

--- a/web/views/page_view.ex
+++ b/web/views/page_view.ex
@@ -16,16 +16,40 @@ defmodule DataDemo.PageView do
     |> Enum.count
   end
 
+  def label_type_name item do
+    "#{item.local_authority_type} #{item.name}"
+  end
+
+  def label_type item do
+    item.local_authority_type
+  end
+
+  def label_name item do
+    item.name
+  end
+
   def england_or_wales do
-    fn item -> item.uk == "ENG" || item.uk == "WLS" end
+    fn item -> (item.uk == "ENG" || item.uk == "WLS") && !end_date_present.(item) end
+  end
+
+  def england do
+    fn item -> item.uk == "ENG" && !end_date_present.(item) end
+  end
+
+  def wales do
+    fn item -> item.uk == "WLS" && !end_date_present.(item) end
   end
 
   def scotland do
-    fn item -> item.uk == "SCT" end
+    fn item -> item.uk == "SCT" && !end_date_present.(item) end
   end
 
   def northern_ireland do
-    fn item -> item.uk == "NIR" end
+    fn item -> item.uk == "NIR" && !end_date_present.(item) end
+  end
+
+  def end_date_present do
+    fn item -> item.end_date |> String.length > 0 end
   end
 
   def local_authority entity, authorities_by_id do
@@ -66,7 +90,7 @@ defmodule DataDemo.PageView do
     if normalise(item.name) == normalise(name) do
       nil
     else
-      item.name
+      "<b>#{item.name}</b>"
     end
   end
 
@@ -74,7 +98,7 @@ defmodule DataDemo.PageView do
     try do
       [legacy_code_for(item, file), legacy_name_for(item, name)]
       |> Enum.filter(&(&1))
-      |> Enum.join(" | ")
+      |> Enum.join(" <br /> ")
     rescue
       KeyError -> ""
     end

--- a/web/views/page_view.ex
+++ b/web/views/page_view.ex
@@ -10,8 +10,22 @@ defmodule DataDemo.PageView do
     |> Enum.join(" ")
   end
 
-  def england_or_wales authority do
-    authority.uk == "ENG" || authority.uk == "WLS"
+  def count_in list, function do
+    list
+    |> Enum.filter(&(function.(&1)))
+    |> Enum.count
+  end
+
+  def england_or_wales do
+    fn item -> item.uk == "ENG" || item.uk == "WLS" end
+  end
+
+  def scotland do
+    fn item -> item.uk == "SCT" end
+  end
+
+  def northern_ireland do
+    fn item -> item.uk == "NIR" end
   end
 
   def local_authority entity, authorities_by_id do


### PR DESCRIPTION
- Show count by country in data code summary table.
- Add local authority type column to comparison table.
- Bold names that don't match in comparison table.
